### PR TITLE
revert: modernモードでのビルドを一時取り止める

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  experimental: {
-    modern: true
-  },
   webpack(config, { defaultLoaders }) {
     config.module.rules.push({
       test: /\.(?:jpe?g|webp)$/,


### PR DESCRIPTION
Regression from #234 
Resolved #238

modernモードでのビルドを行うと`_buildManifest.module.js`と`_ssgManifest.module.js`以外のファイルのビルドが行われなくなってしまいModuleに対応したウェブブラウザーでは正常に動作しなくなってしまう。おそらくNext.js側でのバグと思われるので要調査だが一旦はmodernモードでのビルドを取り止めて一時しのぎをしたい。